### PR TITLE
Melee: oclusión por paredes, barra de vida con gradiente, contraataqu…

### DIFF
--- a/src/Game.hpp
+++ b/src/Game.hpp
@@ -20,7 +20,8 @@ enum class MovementMode
 enum class GameState
 {
     Playing,
-    Victory
+    Victory,
+    GameOver
 };
 
 struct ItemSprites
@@ -71,6 +72,14 @@ public:
     int getHP() const { return hp; }
     int getHPMax() const { return hpMax; }
 
+     enum class EnemyFacing
+    {
+        Down,
+        Up,
+        Left,
+        Right
+    };
+
 private:
     // Jugador
     Player player;
@@ -88,27 +97,24 @@ private:
     float damageCooldown = 0.0f;        // invulnerabilidad breve tras recibir daño
     const float DAMAGE_COOLDOWN = 0.6f; // ~0.6s
 
+    
+    
     // Semillas
     unsigned fixedSeed = 0;
     unsigned runSeed = 0;
     unsigned levelSeed = 0;
-
+    
     // RNG y contexto de run (para spawns)
     std::mt19937 rng;
     RunContext runCtx;
     std::vector<ItemSpawn> items;
-
+    
     // --- Enemigos ---
     std::vector<Enemy> enemies;
     int ENEMY_DETECT_RADIUS_PX = 32 * 6; // ~6 tiles si tileSize=32
-    enum class EnemyFacing
-    {
-        Down,
-        Up,
-        Left,
-        Right
-    };
+   
     std::vector<EnemyFacing> enemyFacing; // mismo tamaño que enemies
+    void enemyTryAttackFacing();
 
     // Cantidad por nivel (ajústalo si quieres)
     int enemiesPerLevel(int lvl) const { return (lvl == 1) ? 3 : (lvl == 2) ? 4


### PR DESCRIPTION
…e mirando; rango fijo 1 casilla

## Resumen
- Se tiene en cuenta el no poder atacar cuando estás dirigido a una pared.
  - Si hay pared/obstáculo justo delante, **no** hay swing, **no** hay cooldown y **no** hay flash.
- **Rango melee actual:** fijo a **1 casilla** (sin espada/pistola aún).
- **Barra de vida enemiga:** ahora usa gradiente **verde → rojo** según el % de vida.
- **Contraataque enemigo más justo:** el enemigo solo daña si está **adyacente** y **mirando al jugador**; y el jugador también debe estar orientado hacia él. Respeta cooldown por enemigo y del jugador.
- **Sincronización de estados:** al spawnear enemigos se reinician HP y cooldowns paralelos.

## ¿Por qué?
- Evitar golpes “a través” de paredes.
- Mejor feedback visual del estado de los enemigos.
- Interacciones de melee más predecibles y justas.

## Relacionado
Closes #7

## Checklist
- [x] Compila y corre localmente (Linux).
- [x] Probado en mapas con y sin niebla.
- [x] Sin cambios en formatos de datos/guardados.
- [ ] Se actualizará el diseño de combate a 3/7 casillas cuando se implementen **espada** y **pistola**.

## Notas / Próximos pasos
- Cuando añadamos inventario:
  - **Espada:** cambiar rango a 3 casillas frontales.
  - **Pistola:** proyectil/alcance 7 casillas (mantener oclusión).
