### PR TITLE
Aclaraciones antes del juego hechas.

### DIFF
--- a/assets/docs/objetos.txt
+++ b/assets/docs/objetos.txt
@@ -1,0 +1,31 @@
+ROGUEBOT:  Guía rápida de objetos
+=================================
+
+LLAVE MAESTRA
+Abre la salida del nivel. Sin llave no puedes salir.
+
+ESCUDO (un solo uso)
+Si el jugador ha recogido el escudo, el próximo golpe del enemigo no te quita vida y el escudo se rompe.
+
+
+PILAS (Buenas / Malas)
+Pila BUENA (pila verde): recupera 1 vida al recogerla.
+Pila MALA (pila roja): quita 1 vida al recogerla.
+
+ESPADA LÁSER (niveles 1–3)
+En cada nivel aumenta el daño:
+Nivel 1 → Azul. Nivel 2 → Verde (solo si ya tienes la 1).
+Nivel 3 → Roja (solo si ya tienes 1 y 2).
+Si no coges la 1 en el primer nivel, en el segundo nivel no aparecerá ninguna espada.
+
+PISTOLA DE PLASMA (niveles 1–2)
+Arma a distancia. Aparece desde el nivel 2.
+Nivel 1 → Azul. Nivel 2 → Roja (más daño/alcance).
+Si no coges la primera pistola, no aparecerá la segunda en el siguiente nivel.
+
+GAFAS 3D (Buenas / Malas)
+Buenas: Amplían tu campo de visión cuando jueges con niebla.
+Malas: Reducen tu campo de visión cuando jueges con niebla.
+
+BATERÍA DE VIDA EXTRA (solo nivel 3)
+Objeto único. Si mueres y la has cogido, te revive automáticamente con aprox. media vida.

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -4,6 +4,7 @@
 #include <cmath>     // para std::floor
 #include <ctime>
 #include <iostream>
+#include <climits>
 
 static inline unsigned now_seed()
 {
@@ -395,16 +396,114 @@ void Game::run()
 void Game::processInput()
 {
 
-    // --- Menú principal: “Pulsa ENTER o haz CLICK para jugar” ---
+    // --- Menú principal: botones con ratón ---
     if (state == GameState::MainMenu)
     {
-        const bool enter = IsKeyPressed(KEY_ENTER);
-        const bool click = IsMouseButtonPressed(MOUSE_LEFT_BUTTON); // en cualquier sitio
-        if (enter || click)
+        // Si el visor está abierto: rueda para scroll + botón "VOLVER"
+        // Si el visor está abierto: rueda para scroll + botón "VOLVER"
+        if (showHelp)
         {
-            newRun(); // crea la partida y pasa a Playing
+            // Geometría del panel (más ancho)
+            int panelW = (int)std::round(screenW * 0.86f);
+            int panelH = (int)std::round(screenH * 0.76f);
+            if (panelW > 1500)
+                panelW = 1500;
+            if (panelH > 900)
+                panelH = 900;
+            int pxl = (screenW - panelW) / 2;
+            int pyl = (screenH - panelH) / 2;
+
+            // Scroll con rueda
+            float wheel = GetMouseWheelMove();
+            if (wheel != 0.0f)
+            {
+                helpScroll -= (int)(wheel * 40);
+                if (helpScroll < 0)
+                    helpScroll = 0;
+            }
+
+            // Cálculo de viewport (reservando footer para el enlace)
+            int margin = 24;
+            int titleSize = (int)std::round(panelH * 0.06f);
+            int top = pyl + margin + titleSize + 16;
+
+            int backFs = std::max(16, (int)std::round(panelH * 0.048f));
+            int footerH = backFs + 16; // reserva para que el texto no tape el enlace
+
+            int viewportH = panelH - (top - pyl) - margin - footerH;
+
+            // Clamp de scroll aproximado (por nº de líneas del archivo)
+            int fontSize = (int)std::round(screenH * 0.022f);
+            if (fontSize < 16)
+                fontSize = 16;
+            int lineH = (int)std::round(fontSize * 1.25f);
+            int lines = 1;
+            for (char c : helpText)
+                if (c == '\n')
+                    ++lines;
+            int maxScroll = std::max(0, lines * lineH - viewportH);
+            if (helpScroll > maxScroll)
+                helpScroll = maxScroll;
+
+            // --- Enlace "VOLVER" (texto rojo) ---
+            const char *backTxt = "VOLVER";
+            int tw = MeasureText(backTxt, backFs);
+            int tx = pxl + panelW - tw - 16;
+            int ty = pyl + panelH - backFs - 12;
+            Rectangle backHit = {(float)(tx - 6), (float)(ty - 4),
+                                 (float)(tw + 12), (float)(backFs + 8)};
+
+            // Click o ESC para cerrar
+            if ((IsMouseButtonPressed(MOUSE_LEFT_BUTTON) &&
+                 CheckCollisionPointRec(GetMousePosition(), backHit)) ||
+                IsKeyPressed(KEY_ESCAPE))
+            {
+                showHelp = false;
+            }
+            return; // no procesar más input mientras está el visor
         }
-        return; // no procesar más input mientras estamos en el menú
+
+        // Geometría de los 2 botones del menú
+        int bw = (int)std::round(screenW * 0.35f);
+        bw = std::clamp(bw, 320, 560);
+        int bh = (int)std::round(screenH * 0.12f);
+        bh = std::clamp(bh, 72, 120);
+        int startY = (int)std::round(screenH * 0.52f);
+        int gap = (int)std::round(screenH * 0.04f);
+
+        Rectangle playBtn = {(float)((screenW - bw) / 2), (float)startY, (float)bw, (float)bh};
+        Rectangle readBtn = {(float)((screenW - bw) / 2), (float)(startY + bh + gap), (float)bw, (float)bh};
+
+        // Click izquierdo: JUGAR o LEER
+        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON))
+        {
+            Vector2 mp = GetMousePosition();
+            if (CheckCollisionPointRec(mp, playBtn))
+            {
+                newRun();
+                return;
+            }
+            if (CheckCollisionPointRec(mp, readBtn))
+            {
+                if (helpText.empty())
+                {
+                    char *buf = LoadFileText("assets/docs/objetos.txt");
+                    if (buf)
+                    {
+                        helpText.assign(buf);
+                        UnloadFileText(buf);
+                    }
+                    else
+                    {
+                        helpText = "No se encontro 'assets/docs/objetos.txt'.\n";
+                    }
+                }
+                showHelp = true;
+                helpScroll = 0;
+                return;
+            }
+        }
+        return; // no procesar más input del juego mientras estamos en el menú
     }
 
     // Reiniciar run completo
@@ -1453,17 +1552,11 @@ void Game::renderMainMenu()
     int titleSize = (int)std::round(screenH * 0.14f);
     int titleW = MeasureText(title, titleSize);
     int titleX = (screenW - titleW) / 2;
-    int titleY = (int)(screenH * 0.42f) - titleSize;
+    int titleY = (int)(screenH * 0.30f) - titleSize;
 
-    // Grosor de contorno proporcional a la altura (p.ej. 1080p -> ~6 px)
     int stroke = std::clamp(screenH / 180, 2, 8);
     int shadow = stroke * 2;
-
-    // 1) Sombra separada (maroon oscuro)
-    Color shadowCol = (Color){90, 0, 0, 255};
-    DrawText(title, titleX + shadow, titleY + shadow, titleSize, shadowCol);
-
-    // 2) Contorno negro en 8 direcciones
+    DrawText(title, titleX + shadow, titleY + shadow, titleSize, Color{90, 0, 0, 255});
     DrawText(title, titleX - stroke, titleY, titleSize, BLACK);
     DrawText(title, titleX + stroke, titleY, titleSize, BLACK);
     DrawText(title, titleX, titleY - stroke, titleSize, BLACK);
@@ -1472,17 +1565,226 @@ void Game::renderMainMenu()
     DrawText(title, titleX + stroke, titleY - stroke, titleSize, BLACK);
     DrawText(title, titleX - stroke, titleY + stroke, titleSize, BLACK);
     DrawText(title, titleX + stroke, titleY + stroke, titleSize, BLACK);
-
-    // 3) Relleno principal
     DrawText(title, titleX, titleY, titleSize, RED);
 
-    // === Hint debajo (sobrio) ===
-    const char *hint = "Pulsa ENTER o haz CLICK para jugar";
-    int hintSize = (int)std::round(screenH * 0.035f);
-    int hintW = MeasureText(hint, hintSize);
-    int hintX = (screenW - hintW) / 2;
-    int hintY = titleY + (int)(titleSize * 1.2f);
-    DrawText(hint, hintX, hintY, hintSize, LIGHTGRAY);
+    // === Botones (ratón) ===
+    int bw = (int)std::round(screenW * 0.46f);
+    bw = std::clamp(bw, 360, 720);
+    int bh = (int)std::round(screenH * 0.12f);
+    bh = std::clamp(bh, 80, 128);
+    int startY = (int)std::round(screenH * 0.52f);
+    int gap = (int)std::round(screenH * 0.045f);
+
+    Rectangle playBtn = {(float)((screenW - bw) / 2), (float)startY, (float)bw, (float)bh};
+    Rectangle readBtn = {(float)((screenW - bw) / 2), (float)(startY + bh + gap), (float)bw, (float)bh};
+
+    Vector2 mp = GetMousePosition();
+
+    auto drawOutlinedText = [&](int x, int y, const char *txt, int fs, Color c)
+    {
+        DrawText(txt, x - 1, y, fs, BLACK);
+        DrawText(txt, x + 1, y, fs, BLACK);
+        DrawText(txt, x, y - 1, fs, BLACK);
+        DrawText(txt, x, y + 1, fs, BLACK);
+        DrawText(txt, x, y, fs, c);
+    };
+
+    // Parte un texto en 2 líneas si es necesario para que quepa en 'maxW'
+    auto splitTwoLines = [&](const std::string &s, int fs, int maxW) -> std::pair<std::string, std::string>
+    {
+        if (MeasureText(s.c_str(), fs) <= maxW)
+            return {s, ""};
+        // Busca el salto óptimo (por espacios)
+        int bestIdx = -1, bestWidth = INT_MAX;
+        for (size_t i = 0; i < s.size(); ++i)
+        {
+            if (s[i] != ' ')
+                continue;
+            std::string a = s.substr(0, i);
+            std::string b = s.substr(i + 1);
+            int wa = MeasureText(a.c_str(), fs);
+            int wb = MeasureText(b.c_str(), fs);
+            int worst = std::max(wa, wb);
+            if (wa <= maxW && wb <= maxW && worst < bestWidth)
+            {
+                bestWidth = worst;
+                bestIdx = (int)i;
+            }
+        }
+        if (bestIdx >= 0)
+        {
+            return {s.substr(0, bestIdx), s.substr(bestIdx + 1)};
+        }
+        // Si no hay espacio válido, devolvemos 1 línea (luego reduciremos fuente)
+        return {s, ""};
+    };
+
+    auto drawPixelButton = [&](Rectangle r, const char *label)
+    {
+        bool hover = CheckCollisionPointRec(mp, r);
+
+        // Sombra
+        DrawRectangle((int)r.x + 3, (int)r.y + 3, (int)r.width, (int)r.height, Color{0, 0, 0, 120});
+
+        // Fondo
+        Color baseBg = Color{25, 25, 30, 255};
+        Color hoverBg = Color{40, 40, 46, 255};
+        DrawRectangleRec(r, hover ? hoverBg : baseBg);
+
+        // Bordes doble rojo
+        Color outer = hover ? Color{200, 40, 40, 255} : Color{150, 25, 25, 255};
+        Color inner = hover ? Color{255, 70, 70, 255} : Color{210, 45, 45, 255};
+        DrawRectangleLinesEx(r, 4, outer);
+        Rectangle innerR = {r.x + 4, r.y + 4, r.width - 8, r.height - 8};
+        DrawRectangleLinesEx(innerR, 2, inner);
+
+        // Texto: intenta 1 línea; si no cabe, 2 líneas; si no, reduce fuente
+        const int padding = 18;
+        int maxW = (int)r.width - padding * 2;
+
+        int fs = (int)std::round(r.height * 0.40f); // base
+        if (fs < 18)
+            fs = 18;
+
+        std::string s = label;
+        auto lines = splitTwoLines(s, fs, maxW);
+        // Si ninguna opción cabe, reducimos tamaño hasta que quepa (mín 14)
+        while (((!lines.second.empty() && (MeasureText(lines.first.c_str(), fs) > maxW ||
+                                           MeasureText(lines.second.c_str(), fs) > maxW)) ||
+                (lines.second.empty() && MeasureText(lines.first.c_str(), fs) > maxW)) &&
+               fs > 14)
+        {
+            fs -= 1;
+            lines = splitTwoLines(s, fs, maxW);
+        }
+
+        // Dibujo centrado (1 o 2 líneas)
+        Color txtCol = RAYWHITE;
+        if (lines.second.empty())
+        {
+            int tw = MeasureText(lines.first.c_str(), fs);
+            int tx = (int)(r.x + (r.width - tw) / 2);
+            int ty = (int)(r.y + (r.height - fs) / 2);
+            drawOutlinedText(tx, ty, lines.first.c_str(), fs, txtCol);
+        }
+        else
+        {
+            int tw1 = MeasureText(lines.first.c_str(), fs);
+            int tw2 = MeasureText(lines.second.c_str(), fs);
+            int totalH = fs * 2 + (int)(fs * 0.20f);
+            int baseY = (int)(r.y + (r.height - totalH) / 2);
+            int tx1 = (int)(r.x + (r.width - tw1) / 2);
+            int tx2 = (int)(r.x + (r.width - tw2) / 2);
+            drawOutlinedText(tx1, baseY, lines.first.c_str(), fs, txtCol);
+            drawOutlinedText(tx2, baseY + fs + (int)(fs * 0.20f), lines.second.c_str(), fs, txtCol);
+        }
+    };
+
+    drawPixelButton(playBtn, "JUGAR");
+    drawPixelButton(readBtn, "LEER ANTES DE JUGAR");
+
+    // Overlay de ayuda (si está abierto)
+    if (showHelp)
+        renderHelpOverlay();
 
     EndDrawing();
+}
+
+void Game::renderHelpOverlay()
+{
+    // Fondo oscuro translúcido
+    DrawRectangle(0, 0, screenW, screenH, (Color){0, 0, 0, 180});
+
+    // Panel más ancho/alto
+    int panelW = (int)std::round(screenW * 0.86f);
+    int panelH = (int)std::round(screenH * 0.76f);
+    if (panelW > 1500)
+        panelW = 1500;
+    if (panelH > 900)
+        panelH = 900;
+    int px = (screenW - panelW) / 2;
+    int py = (screenH - panelH) / 2;
+
+    DrawRectangle(px, py, panelW, panelH, (Color){20, 20, 20, 255});
+    DrawRectangleLines(px, py, panelW, panelH, (Color){220, 220, 220, 255});
+
+    // Título
+    const char *title = "Guia de objetos";
+    int titleSize = (int)std::round(panelH * 0.06f);
+    int tW = MeasureText(title, titleSize);
+    DrawText(title, px + (panelW - tW) / 2, py + 12, titleSize, RAYWHITE);
+
+    // Márgenes y viewport (reservando footer para el enlace)
+    int margin = 24;
+    int top = py + margin + titleSize + 16;
+    int left = px + margin;
+    int viewportW = panelW - margin * 2;
+
+    int backFs = std::max(16, (int)std::round(panelH * 0.048f));
+    int footerH = backFs + 16; // altura reservada abajo
+    int viewportH = panelH - (top - py) - margin - footerH;
+
+    // Texto scrollable (línea a línea según \n)
+    BeginScissorMode(left, top, viewportW, viewportH);
+
+    int fontSize = (int)std::round(screenH * 0.022f);
+    if (fontSize < 16)
+        fontSize = 16;
+    int lineH = (int)std::round(fontSize * 1.25f);
+
+    // Clamp de scroll
+    int lines = 1;
+    for (char c : helpText)
+        if (c == '\n')
+            ++lines;
+    int totalH = lines * lineH;
+    int maxScroll = std::max(0, totalH - viewportH);
+    if (helpScroll > maxScroll)
+        helpScroll = maxScroll;
+
+    // Pintado del archivo (sin wrap; el panel ya es más ancho)
+    int y = top - helpScroll;
+    std::string line;
+    line.reserve(256);
+    for (size_t i = 0; i <= helpText.size(); ++i)
+    {
+        if (i == helpText.size() || helpText[i] == '\n')
+        {
+            DrawText(line.c_str(), left, y, fontSize, (Color){230, 230, 230, 255});
+            y += lineH;
+            line.clear();
+        }
+        else
+        {
+            line.push_back(helpText[i]);
+        }
+    }
+    EndScissorMode();
+
+    // --- Enlace "VOLVER" en rojo (sin caja) ---
+    const char *backTxt = "VOLVER";
+    int tw = MeasureText(backTxt, backFs);
+    int tx = px + panelW - tw - 16;
+    int ty = py + panelH - backFs - 12;
+    Rectangle backHit = {(float)(tx - 6), (float)(ty - 4),
+                         (float)(tw + 12), (float)(backFs + 8)};
+
+    bool hover = CheckCollisionPointRec(GetMousePosition(), backHit);
+    Color link = hover ? (Color){255, 100, 100, 255} : (Color){230, 60, 60, 255};
+
+    // Sombra suave + texto
+    DrawText(backTxt, tx + 1, ty + 1, backFs, (Color){0, 0, 0, 160});
+    DrawText(backTxt, tx, ty, backFs, link);
+
+    // Subrayado al pasar el ratón
+    if (hover)
+    {
+        int underlineY = ty + backFs + 2;
+        DrawLine(tx, underlineY, tx + tw, underlineY, link);
+    }
+
+    // (opcional) hint de teclado a la izquierda del footer
+    // const char* hint = "ESC para volver";
+    // int hs = std::max(14, (int)std::round(panelH * 0.035f));
+    // DrawText(hint, px + 16, py + panelH - footerH + (footerH - hs)/2, hs, (Color){200,200,200,255});
 }

--- a/src/Game.hpp
+++ b/src/Game.hpp
@@ -3,6 +3,7 @@
 
 #include <random>
 #include <vector>
+#include <string>
 
 #include "Map.hpp"
 #include "HUD.hpp"
@@ -73,7 +74,7 @@ public:
     int getHP() const { return hp; }
     int getHPMax() const { return hpMax; }
 
-     enum class EnemyFacing
+    enum class EnemyFacing
     {
         Down,
         Up,
@@ -98,22 +99,20 @@ private:
     float damageCooldown = 0.0f;        // invulnerabilidad breve tras recibir daño
     const float DAMAGE_COOLDOWN = 0.6f; // ~0.6s
 
-    
-    
     // Semillas
     unsigned fixedSeed = 0;
     unsigned runSeed = 0;
     unsigned levelSeed = 0;
-    
+
     // RNG y contexto de run (para spawns)
     std::mt19937 rng;
     RunContext runCtx;
     std::vector<ItemSpawn> items;
-    
+
     // --- Enemigos ---
     std::vector<Enemy> enemies;
     int ENEMY_DETECT_RADIUS_PX = 32 * 6; // ~6 tiles si tileSize=32
-   
+
     std::vector<EnemyFacing> enemyFacing; // mismo tamaño que enemies
     void enemyTryAttackFacing();
 
@@ -124,9 +123,8 @@ private:
     // Helpers de enemigos
     void spawnEnemiesForLevel();                   // crear enemigos al iniciar nivel
     void updateEnemiesAfterPlayerMove(bool moved); // IA y colisión básica (placeholder)
-    void drawEnemies() const;  
+    void drawEnemies() const;
     void takeDamage(int amount);
-                 
 
     // Movimiento
     MovementMode moveMode = MovementMode::StepByStep;
@@ -149,7 +147,8 @@ private:
     void processInput();
     void update();
     void render();
-    void renderMainMenu();                         
+    void renderMainMenu();
+    void renderHelpOverlay();
     Rectangle uiCenterRect(float w, float h) const;
     void clampCameraToMap();
 
@@ -184,6 +183,15 @@ private:
 
     // Sprites de ítems
     ItemSprites itemSprites;
+
+    // --- Menú v2: visor “Leer antes de jugar” ---
+    bool showHelp = false; // si está abierto el visor
+    int helpScroll = 0;    // desplazamiento vertical del texto
+    std::string helpText;
+    Rectangle btnPlay{0, 0, 0, 0};
+    Rectangle btnRead{0, 0, 0, 0};
+    Rectangle btnBack{0, 0, 0, 0}; // botón "Volver" del panel de ayuda
+
 };
 
 #endif


### PR DESCRIPTION
## Resumen
Se mejora el visor de **“Guía de objetos”** del menú principal para que el texto se lea completo y el control de salida sea más discreto:

- Panel más **ancho y alto** (≈86% x 76%; máx. 1500×900).
- Reserva de **footer** para que el contenido nunca tape el control de salida.
- **“VOLVER”** pasa de botón a **texto rojo clicable** (hover + subrayado).  
  También cierra con **ESC**.
- Ajuste del **scroll/clamp** usando el nuevo viewport (con footer).
- Sin cambios de gameplay ni dependencias.

## Relacionado
Closes #22  
Closes #23

## Checklist
- [ x] CI pasa
- [ x] Probado en Linux
- [ x] Sigue convenciones de commits

## Notas
Si en el futuro entra documentación más ancha, podemos añadir word-wrap por palabras para evitar clipping aún con panel estrecho.
