### PR TITLE
Arreglos del menú de opciones para el mando.

### DIFF
--- a/src/core/GameInput.cpp
+++ b/src/core/GameInput.cpp
@@ -932,20 +932,19 @@ void Game::handleOptionsInput()
         if (std::fabs(stickRX) > 0.2f) { 
             audioVolume = std::clamp(audioVolume + (stickRX * 0.01f), 0.0f, 1.0f);
             SetMasterVolume(audioVolume);
-            mainMenuSelection = 1; 
         }
     }
 
     // Mover cursor
-    if (up) { mainMenuSelection--; if (mainMenuSelection < 0) mainMenuSelection = 2; }
-    if (down) { mainMenuSelection++; if (mainMenuSelection > 2) mainMenuSelection = 0; }
+    if (up) { mainMenuSelection--; if (mainMenuSelection < 0) mainMenuSelection = 1; }
+    if (down) { mainMenuSelection++; if (mainMenuSelection > 1) mainMenuSelection = 0; }
 
     
     if (enter) {
         if (mainMenuSelection == 0) {
             pendingDifficulty = (Difficulty)(((int)pendingDifficulty + 1) % 3);
         }
-        else if (mainMenuSelection == 2) {
+        else if (mainMenuSelection == 1) {
             // Aquí es donde el botón 'A' ejecuta la salida
             if (pendingDifficulty != difficulty && previousState == GameState::Paused) {
                 showDifficultyWarning = true;
@@ -956,18 +955,17 @@ void Game::handleOptionsInput()
         }
     }
 
-    // Volumen con flechas/D-Pad
-    if (mainMenuSelection == 1) {
-        float step = 0.01f;
-        if (IsKeyDown(KEY_LEFT) || (IsGamepadAvailable(gpId) && IsGamepadButtonDown(gpId, GAMEPAD_BUTTON_LEFT_FACE_LEFT))) {
-            audioVolume = std::clamp(audioVolume - step, 0.0f, 1.0f);
-            SetMasterVolume(audioVolume);
-        }
-        if (IsKeyDown(KEY_RIGHT) || (IsGamepadAvailable(gpId) && IsGamepadButtonDown(gpId, GAMEPAD_BUTTON_LEFT_FACE_RIGHT))) {
-            audioVolume = std::clamp(audioVolume + step, 0.0f, 1.0f);
-            SetMasterVolume(audioVolume);
-        }
+    float step = 0.01f;
+    if (IsKeyDown(KEY_LEFT) || (IsGamepadAvailable(gpId) && IsGamepadButtonDown(gpId, GAMEPAD_BUTTON_LEFT_FACE_LEFT))) {
+        audioVolume = std::clamp(audioVolume - step, 0.0f, 1.0f);
+        SetMasterVolume(audioVolume);
     }
+    if (IsKeyDown(KEY_RIGHT) || (IsGamepadAvailable(gpId) && IsGamepadButtonDown(gpId, GAMEPAD_BUTTON_LEFT_FACE_RIGHT))) {
+        audioVolume = std::clamp(audioVolume + step, 0.0f, 1.0f);
+        SetMasterVolume(audioVolume);
+    }
+        
+    
 
     // --------------------------------------------------------
     // 3. Lógica de RATÓN


### PR DESCRIPTION
## Resumen

Breve descripción del cambio que introduce este PR:

- ¿Qué se ha hecho?

1. Se ha corregido la lógica de selección/navegación del menú de Opciones con mando para que el botón **A** (aceptar) ejecute correctamente la acción de **VOLVER**.
2. Se ha alineado el índice del botón "VOLVER" con el que se usa en el renderizado (render = 1, input estaba comprobando = 2).
3. Se ha ajustado la navegación vertical para que solo existan **2 filas navegables**: (0) Dificultad y (1) Volver, evitando una “fila fantasma” causada por el volumen.

- ¿Por qué se ha hecho?

1. Con mando, al colocarse sobre "VOLVER" y pulsar **A**, no se volvía al menú anterior porque la lógica de input esperaba otra fila/índice.
2. El volumen se controla con el joystick derecho y estaba interfiriendo con la interpretación de filas.



## Relacionado

- Relacionado con: #72 


## Tipo de cambio

Marca todo lo que aplique:

- [ ] Feature nueva (nueva funcionalidad de cara al jugador)
- [ ] Mejora de una funcionalidad existente
- [x] Fix de bug
- [ ] Refactor interno (sin cambios visibles para el jugador)
- [ ] Mejora de build / CI / empaquetado (.deb, Makefile, etc.)
- [ ] Documentación (README, GDD, Entregables, etc.)
- [ ] Otro (`...`)
