### PR TITLE
Añadir labels unit/integration en CTest

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -258,7 +258,7 @@ add_test(NAME map_deterministic_seed COMMAND rb_test_map_deterministic_seed)
 
 set_tests_properties(map_deterministic_seed PROPERTIES
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  LABELS "map"
+  LABELS "unit;map"
 )
 
 
@@ -280,7 +280,7 @@ add_test(NAME find_exit_tile COMMAND rb_test_find_exit_tile)
 
 set_tests_properties(find_exit_tile PROPERTIES
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  LABELS "map"
+  LABELS "unit;map"
 )
 
 
@@ -301,7 +301,7 @@ add_test(NAME map_is_walkable COMMAND rb_test_map_is_walkable)
 
 set_tests_properties(map_is_walkable PROPERTIES
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  LABELS "map"
+  LABELS "unit;map"
 )
 
 
@@ -323,7 +323,7 @@ add_test(NAME map_boss_arena_structure COMMAND rb_test_map_boss_arena_structure)
 
 set_tests_properties(map_boss_arena_structure PROPERTIES
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  LABELS "map"
+  LABELS "unit;map"
 )
 
 
@@ -345,7 +345,7 @@ add_test(NAME map_generate_places_exit COMMAND rb_test_map_generate_places_exit)
 
 set_tests_properties(map_generate_places_exit PROPERTIES
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  LABELS "map"
+  LABELS "unit;map"
 )
 
 
@@ -367,7 +367,7 @@ add_test(NAME map_set_tile_bounds COMMAND rb_test_map_set_tile_bounds)
 
 set_tests_properties(map_set_tile_bounds PROPERTIES
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  LABELS "map"
+  LABELS "unit;map"
 )
 
 
@@ -389,7 +389,7 @@ add_test(NAME map_generate_sets_dimensions COMMAND rb_test_map_generate_sets_dim
 
 set_tests_properties(map_generate_sets_dimensions PROPERTIES
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  LABELS "map"
+  LABELS "unit;map"
 )
 
 
@@ -411,7 +411,7 @@ add_test(NAME map_generate_exit_in_bounds COMMAND rb_test_map_generate_exit_in_b
 
 set_tests_properties(map_generate_exit_in_bounds PROPERTIES
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  LABELS "map"
+  LABELS "unit;map"
 )
 
 
@@ -433,7 +433,7 @@ add_test(NAME map_exit_tile_is_exit COMMAND rb_test_map_exit_tile_is_exit)
 
 set_tests_properties(map_exit_tile_is_exit PROPERTIES
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  LABELS "map"
+  LABELS "unit;map"
 )
 
 
@@ -455,7 +455,7 @@ add_test(NAME map_generate_creates_some_floor COMMAND rb_test_map_generate_creat
 
 set_tests_properties(map_generate_creates_some_floor PROPERTIES
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  LABELS "map"
+  LABELS "unit;map"
 )
 
 


### PR DESCRIPTION
## Resumen

Breve descripción del cambio que introduce este PR:

- Se han añadido **labels de CTest** para separar explícitamente los tests **unit** y **integration**.
- Se mantiene la **categoría funcional existente** de cada test (utils, map, assets, i18n) como segundo label.
- Esto permite ejecutar y filtrar tests unitarios y de integración de forma independiente.

Este cambio no modifica la lógica del juego ni el comportamiento de los tests, solo su clasificación.

Afecta a:
- **Tests / build (CTest, CMake)**


## 🔗 Relacionado

- Relacionado con: #111 


## Tipo de cambio

Marca todo lo que aplique:

- [ ] Feature nueva (nueva funcionalidad de cara al jugador)
- [ ] Mejora de una funcionalidad existente
- [ ] Fix de bug
- [x] Refactor interno (sin cambios visibles para el jugador)
- [x] Mejora de build / CI / empaquetado (.deb, Makefile, etc.)
- [ ] Documentación (README, GDD, Entregables, etc.)
- [ ] Otro (`clasificación de tests`)


##  Cómo se ha probado

Se ha verificado localmente que los tests quedan correctamente clasificados y filtrables mediante CTest.

Comandos utilizados:

```bash
cmake -S . -B build-tests
cmake --build build-tests

ctest --test-dir build-tests -L unit -N
ctest --test-dir build-tests -L integration -N

ctest --test-dir build-tests -L unit --output-on-failure
ctest --test-dir build-tests -L integration --output-on-failure
