### PR TITLE
Chore/ci separar unit integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
+    env:
+      LANG: es_ES.UTF-8
+      LC_ALL: es_ES.UTF-8
+      LANGUAGE: es
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,16 +59,10 @@ jobs:
 
       - name: Test (CTest) - unit
         run: |
-          export LANG=es_ES.UTF-8
-          export LC_ALL=es_ES.UTF-8
-          export LANGUAGE=es
           locale
           ctest --test-dir build-tests -L unit --output-on-failure
 
       - name: Test (CTest) - integration
         run: |
-          export LANG=es_ES.UTF-8
-          export LC_ALL=es_ES.UTF-8
-          export LANGUAGE=es
           locale
           ctest --test-dir build-tests -L integration --output-on-failure


### PR DESCRIPTION
## Resumen

- Se separa la ejecución de tests en CI en dos bloques: **unit** e **integration** usando labels de CTest.
- Se mantiene el entorno de locales necesario para i18n mediante variables de entorno del job.
- Se añaden trazas para listar tests por label y facilitar depuración en CI.

Afecta a:
- **CI**

## Relacionado

- Closes: #111 

## Tipo de cambio

- [ ] Feature nueva (nueva funcionalidad de cara al jugador)
- [ ] Mejora de una funcionalidad existente
- [ ] Fix de bug
- [ ] Refactor interno (sin cambios visibles para el jugador)
- [x] Mejora de build / CI / empaquetado (.deb, Makefile, etc.)
- [ ] Documentación (README, GDD, Entregables, etc.)
- [ ] Otro (`...`)

## Cómo se ha probado

Verificado en CI (GitHub Actions) ejecutando los tests por separado:

```bash
ctest --test-dir build-tests -L unit --output-on-failure
ctest --test-dir build-tests -L integration --output-on-failure
