### PR TITLE
Utilizar rb_label_test para labels de assets

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -598,5 +598,5 @@ add_test(NAME assetpath_known_file_exists COMMAND rb_test_assetpath_known_file_e
 
 set_tests_properties(assetpath_known_file_exists PROPERTIES
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  LABELS "integration;assets"
 )
+rb_label_test(assetpath_known_file_exists integration assets)


### PR DESCRIPTION
## Resumen

- Se ha unificado el etiquetado de los tests de **assets** usando el helper `rb_label_test(...)`.
- Se mantiene `WORKING_DIRECTORY` con `set_tests_properties`, pero los labels se asignan de forma consistente con el helper.
- No cambia la lógica de los tests ni su clasificación (siguen siendo `integration;assets`).

Afecta a:
- **Tests / CMake / CTest**

## Relacionado

- Relacionado con: #114

## Tipo de cambio

- [ ] Feature nueva (nueva funcionalidad de cara al jugador)
- [ ] Mejora de una funcionalidad existente
- [ ] Fix de bug
- [x] Refactor interno (sin cambios visibles para el jugador)
- [ ] Mejora de build / CI / empaquetado (.deb, Makefile, etc.)
- [ ] Documentación (README, GDD, Entregables, etc.)
- [ ] Otro (`...`)

## Cómo se ha probado

```bash
cmake --build build-tests
ctest --test-dir build-tests -L integration --output-on-failure
